### PR TITLE
[fix] Passing cross origin header through

### DIFF
--- a/imagesloaded.js
+++ b/imagesloaded.js
@@ -273,6 +273,7 @@ LoadingImage.prototype.check = function() {
 
   // If none of the checks above matched, simulate loading on detached element.
   this.proxyImage = new Image();
+  this.proxyImage.crossOrigin = this.img.crossOrigin;
   this.proxyImage.addEventListener( 'load', this );
   this.proxyImage.addEventListener( 'error', this );
   // bind to image as well for Firefox. #191


### PR DESCRIPTION
Currently this repo doesn't support passing the cross origin header through when it creates a proxy image. This fix adds a pass through of whatever the the crossOrigin value is. The solution was taken from a PR that was never merged in the original library

https://github.com/desandro/imagesloaded/pull/204/files#diff-9e6c9bf6f199df6f8abc816298b2af70R292